### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/elkins/TorsionTuner/security/code-scanning/2](https://github.com/elkins/TorsionTuner/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/lint.yml` at the workflow root so it applies to all jobs (current and future unless overridden). For this lint-only workflow, `contents: read` is sufficient and preserves existing behavior.

**What to change:**
- File: `.github/workflows/lint.yml`
- Insert after the `on:` triggers (before `jobs:`):
  - `permissions:`
  - `  contents: read`

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
