### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/elkins/TorsionTuner/security/code-scanning/1](https://github.com/elkins/TorsionTuner/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/test.yml` at the workflow root (top-level, alongside `name` and `on`) so all jobs inherit least-privilege defaults unless overridden.  
For this workflow, the minimal safe permission is:

- `contents: read`

This preserves current functionality (`actions/checkout` and test execution) while preventing unnecessary write scopes on `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
